### PR TITLE
add jshint comment to remove es6 error messages in Atom

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
+/*jshint esversion: 6 */
 require('./styles');
 require('../css/main');
 require('../css/reset');
+
 let NewTD = require('./new-td');
 let newTDBoxCreator = require('./box-creator');
 


### PR DESCRIPTION
@ejwill04 added one line of code to remove the es6 error messages in Atom.